### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ dev-shell-essentials
 ```bash
 wget https://github.com/kepkin/dev-shell-essentials/archive/master.zip -O dev-shell-essentials.zip &&
   unzip dev-shell-essentials.zip &&
-  source dev-shell-essentials-master/dev-shell-essentials.sh
-
+  cd dev-shell-essentials-master &&
+  source dev-shell-essentials.sh &&
+  cd -
 ```
 
 Or using git
@@ -24,3 +25,25 @@ cd dev-shell-essentials
 source dev-shell-essentials.sh
 
 ```
+
+## Optional steps
+
+### For ZSH users
+
+```shell
+function highlight() {
+	declare -A fg_color_map
+	fg_color_map[black]=30
+	fg_color_map[red]=31
+	fg_color_map[green]=32
+	fg_color_map[yellow]=33
+	fg_color_map[blue]=34
+	fg_color_map[magenta]=35
+	fg_color_map[cyan]=36
+	 
+	fg_c=$(echo -e "\e[1;${fg_color_map[$1]}m")
+	c_rs=$'\e[0m'
+	sed -u s"/$2/$fg_c\0$c_rs/g"
+}
+```
+> Thanks [@alexzanderr](https://github.com/alexzanderr) for [this workaround](https://github.com/kepkin/dev-shell-essentials/issues/5#issuecomment-898277655)


### PR DESCRIPTION
- added quick fix to install command snippet
- added workaround for zsh

This resolves the issue [Does not work with zsh #5 ](https://github.com/kepkin/dev-shell-essentials/issues/5)